### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Use `curl` to send an authenticated request.
 $ curl -v -H "Authorization: Bearer 123456789" http://127.0.0.1:3000/
 ```
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/vK9dyjRnnWsMzzJTQ57fRJpH/passport/express-4.x-http-bearer-example'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/vK9dyjRnnWsMzzJTQ57fRJpH/passport/express-4.x-http-bearer-example.svg' /></a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8